### PR TITLE
docs: add v1.0.0 and v1.1.0 release documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,31 @@ The format is inspired by Keep a Changelog and this project follows Semantic Ver
 
 - (none yet)
 
+## 1.1.0 - 2026-04-04
+
+### Added
+
+- Structured JSON audit logging module (`audit.rs`) with 12 event types covering authentication, run lifecycle, case operations, and server lifecycle (#98).
+  - File sink (JSON lines) and in-memory ring buffer for recent events.
+  - `GET /api/v1/audit/events?limit=N` endpoint to query recent audit events.
+  - `--audit-log <PATH>` CLI flag to enable file-based audit trail.
+  - Events emitted for: `AuthSuccess`, `AuthFailure`, `RunCreated`, `RunCompleted`, `RunFailed`, `RunCancelled`, `CaseCreated`, `CaseUpdated`, `ToolExecuted`, `ToolPolicyDenied`, `ServerStarted`, `ServerStopped`.
+- Case management API for grouping related investigation runs (#97).
+  - `POST /api/v1/cases` — create a new investigation case with title and optional description.
+  - `GET /api/v1/cases` — list all cases with run count aggregates.
+  - `GET /api/v1/cases/{id}` — retrieve a single case with linked run statistics.
+  - `PATCH /api/v1/cases/{id}` — update case title, description, or status (open/investigating/closed).
+  - `GET /api/v1/cases/{id}/runs` — list runs linked to a case.
+  - `case_id` field on `POST /api/v1/runs` request body to associate runs with cases.
+  - SQLite schema v2 migration: `cases` table and `case_id` column on `runs` (auto-migrated).
+- Evidence-backed narrative report format via `--format narrative` (#96).
+  - Executive Summary with task, case reference, finding count, max severity, and duration.
+  - Risk Assessment severity distribution table.
+  - Investigation Timeline with step-by-step tool execution log.
+  - Detailed Findings with confidence level, evidence chain, and recommended action.
+  - Supplementary Findings and Conclusion sections.
+  - Report metadata footer (model tier, inference mode, live metrics).
+
 ## 1.0.0 - 2026-04-06
 
 ### Added

--- a/docs/upgrades.md
+++ b/docs/upgrades.md
@@ -1,5 +1,68 @@
 # Upgrade Notes
 
+## v1.1.0
+
+### Breaking/visible changes
+
+- SQLite database schema automatically migrates from v1 to v2 on first use. The migration adds a `cases` table and a `case_id` column to the `runs` table. Existing databases are upgraded in-place; no manual action is required.
+- New `narrative` output format available via `--format narrative`. Existing formats (`json`, `summary`, `markdown`) are unchanged.
+- New API endpoints added under `/api/v1/cases/*` and `/api/v1/audit/events`. Existing endpoints are unchanged.
+
+### Migration examples
+
+To enable audit logging, pass the new `--audit-log` flag:
+
+```powershell
+wraithrun serve --audit-log ./audit.jsonl
+```
+
+To create and use cases via the API:
+
+```bash
+# Create a case
+curl -X POST http://127.0.0.1:8080/api/v1/cases \
+  -H "Authorization: Bearer <TOKEN>" \
+  -H "Content-Type: application/json" \
+  -d '{"title": "Incident 2026-04-04", "description": "Suspicious SSH activity"}'
+
+# Start a run linked to a case
+curl -X POST http://127.0.0.1:8080/api/v1/runs \
+  -H "Authorization: Bearer <TOKEN>" \
+  -H "Content-Type: application/json" \
+  -d '{"task": "Investigate SSH keys", "case_id": "<CASE-UUID>"}'
+```
+
+To generate a narrative report:
+
+```powershell
+wraithrun --task "Check suspicious ports" --format narrative
+```
+
+## v1.0.0
+
+### Breaking/visible changes
+
+- New `api_server` crate added to the workspace. This is an additive change; the CLI continues to work identically without `--serve`.
+- When `--serve` is used, WraithRun starts an HTTP server on `127.0.0.1:8080` (configurable via `--port`) instead of running a single investigation and exiting.
+- Bearer token authentication is now required for all API endpoints except `/api/v1/health`. A random token is printed at startup unless `--api-token` is provided.
+- SQLite persistence is opt-in via `--database <PATH>`. Without it, runs are stored in memory only.
+
+### Migration examples
+
+Start the API server:
+
+```powershell
+wraithrun serve --port 8080 --database ./wraithrun.db
+```
+
+Use a fixed API token for automation:
+
+```powershell
+wraithrun serve --api-token my-secret-token
+```
+
+Existing CLI workflows (non-serve) are completely unchanged.
+
 ## v0.13.0
 
 ### Breaking/visible changes


### PR DESCRIPTION
﻿Adds missing CHANGELOG.md section for v1.1.0 and docs/upgrades.md sections for both v1.0.0 and v1.1.0.

Fixes release preflight check failures for tags v1.0.0 and v1.1.0.
