### PR TITLE
chore: bump version to 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ The format is inspired by Keep a Changelog and this project follows Semantic Ver
 
 ### Added
 
+- (none yet)
+
+### Changed
+
+- (none yet)
+
+### Fixed
+
+- (none yet)
+
+## 1.2.0 - 2026-04-05
+
+### Added
+
 - **Dashboard UX overhaul** (#99): 5-tab layout (Runs, Findings, Cases, Compare, Health) with SVG donut severity charts, clickable evidence chains, run comparison diff view, JSON/CSV export, real-time progress spinners, and case management panel.
 - **Tool plugin API** (#102): extend WraithRun with external tool plugins via `tool.toml` manifests and subprocess JSON I/O.
   - `--tools-dir` and `--allowed-plugins` CLI flags.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,7 +83,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "api_server"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -308,7 +308,7 @@ dependencies = [
 
 [[package]]
 name = "core_engine"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -372,7 +372,7 @@ dependencies = [
 
 [[package]]
 name = "cyber_tools"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "async-trait",
  "serde",
@@ -791,7 +791,7 @@ dependencies = [
 
 [[package]]
 name = "inference_bridge"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2117,7 +2117,7 @@ dependencies = [
 
 [[package]]
 name = "wraithrun"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "api_server",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2021"
-version = "1.1.0"
+version = "1.2.0"
 license = "MIT"
 
 [workspace.dependencies]


### PR DESCRIPTION
Version bump to 1.2.0 with release date in CHANGELOG.md and fresh Unreleased section.