### PR TITLE
feat: complete v1.3.0 — doctor diagnostics, --backend flag, conformance tests

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -485,7 +485,9 @@ use core_engine::{
 };
 use cyber_tools::{ToolRegistry, ToolSpec};
 use inference_bridge::onnx_vitis::{inspect_runtime_compatibility, RuntimeCompatibilitySeverity};
-use inference_bridge::{probe_model_capability, ModelConfig, OnnxVitisEngine, VitisEpConfig};
+use inference_bridge::{
+    backend::ProviderRegistry, probe_model_capability, ModelConfig, OnnxVitisEngine, VitisEpConfig,
+};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use sha2::{Digest, Sha256};
@@ -774,6 +776,11 @@ struct Cli {
     #[arg(long)]
     vitis_cache_key: Option<String>,
 
+    /// Override inference backend selection (e.g. "cpu", "vitis").
+    /// Use "auto" or omit to auto-select the highest-priority available backend.
+    #[arg(long, value_name = "NAME")]
+    backend: Option<String>,
+
     #[arg(long, value_enum)]
     capability_override: Option<CapabilityOverride>,
 }
@@ -802,6 +809,13 @@ struct SettingsFragment {
     vitis_config: Option<String>,
     vitis_cache_dir: Option<String>,
     vitis_cache_key: Option<String>,
+    backend: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+struct InferenceConfig {
+    backend: Option<String>,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -810,6 +824,8 @@ struct FileConfig {
     #[serde(flatten)]
     defaults: SettingsFragment,
     profiles: HashMap<String, SettingsFragment>,
+    #[serde(default)]
+    inference: InferenceConfig,
 }
 
 #[derive(Debug, Clone)]
@@ -836,6 +852,7 @@ struct RuntimeConfig {
     vitis_config: Option<String>,
     vitis_cache_dir: Option<String>,
     vitis_cache_key: Option<String>,
+    backend: Option<String>,
     capability_override: Option<CapabilityOverride>,
     tools_dir: Option<PathBuf>,
     allowed_plugins: Vec<String>,
@@ -865,6 +882,7 @@ struct RuntimeConfigView {
     vitis_config: Option<String>,
     vitis_cache_dir: Option<String>,
     vitis_cache_key: Option<String>,
+    backend: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -891,6 +909,7 @@ struct RuntimeConfigSources {
     vitis_config: String,
     vitis_cache_dir: String,
     vitis_cache_key: String,
+    backend: String,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -1088,6 +1107,8 @@ struct DoctorSummaryView {
 struct DoctorReportView<'a> {
     summary: DoctorSummaryView,
     checks: &'a [DoctorCheck],
+    #[serde(skip_serializing_if = "<[DoctorBackendEntry]>::is_empty")]
+    backends: &'a [DoctorBackendEntry],
 }
 
 #[derive(Debug, Default, Serialize)]
@@ -1155,6 +1176,7 @@ impl RuntimeConfig {
             vitis_config: None,
             vitis_cache_dir: None,
             vitis_cache_key: None,
+            backend: None,
             capability_override: None,
             tools_dir: None,
             allowed_plugins: Vec::new(),
@@ -1222,6 +1244,9 @@ impl RuntimeConfig {
         if let Some(vitis_cache_key) = &fragment.vitis_cache_key {
             self.vitis_cache_key = Some(vitis_cache_key.clone());
         }
+        if let Some(backend) = &fragment.backend {
+            self.backend = Some(backend.clone());
+        }
     }
 }
 
@@ -1250,6 +1275,7 @@ impl RuntimeConfigSources {
             vitis_config: "default".to_string(),
             vitis_cache_dir: "default".to_string(),
             vitis_cache_key: "default".to_string(),
+            backend: "default".to_string(),
         }
     }
 }
@@ -1338,6 +1364,23 @@ struct DoctorCheck {
 #[derive(Debug, Default, Serialize)]
 struct DoctorReport {
     checks: Vec<DoctorCheck>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    backends: Vec<DoctorBackendEntry>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct DoctorBackendEntry {
+    name: String,
+    priority: u32,
+    available: bool,
+    diagnostics: Vec<DoctorBackendDiag>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct DoctorBackendDiag {
+    status: DoctorStatus,
+    check: String,
+    detail: String,
 }
 
 impl DoctorReport {
@@ -2215,6 +2258,13 @@ fn merge_sources(
     if let Some(file_config) = file_config {
         resolved.apply_fragment(&file_config.defaults);
 
+        // Apply [inference] section if present.
+        if let Some(backend) = &file_config.inference.backend {
+            if backend != "auto" {
+                resolved.backend = Some(backend.clone());
+            }
+        }
+
         if let Some(profile_name) = profile.as_deref() {
             if let Some(profile_settings) = lookup_profile(&file_config.profiles, profile_name) {
                 resolved.apply_fragment(profile_settings);
@@ -2272,6 +2322,16 @@ fn merge_sources_with_explanation(
             .map(|path| format!("config defaults ({})", path.display()))
             .unwrap_or_else(|| "config defaults".to_string());
         apply_fragment_with_source(&mut resolved, &mut sources, &file_config.defaults, &source);
+
+        // Apply [inference] section if present.
+        if let Some(backend) = &file_config.inference.backend {
+            if backend != "auto" {
+                resolved.backend = Some(backend.clone());
+                sources.backend = file_config_path
+                    .map(|path| format!("config [inference] ({})", path.display()))
+                    .unwrap_or_else(|| "config [inference]".to_string());
+            }
+        }
 
         if let Some(profile_name) = profile.as_deref() {
             if let Some(profile_settings) = lookup_profile(&file_config.profiles, profile_name) {
@@ -2477,6 +2537,7 @@ fn env_settings_fragment() -> Result<SettingsFragment> {
         vitis_config: read_env_string("WRAITHRUN_VITIS_CONFIG")?,
         vitis_cache_dir: read_env_string("WRAITHRUN_VITIS_CACHE_DIR")?,
         vitis_cache_key: read_env_string("WRAITHRUN_VITIS_CACHE_KEY")?,
+        backend: read_env_string("WRAITHRUN_BACKEND")?,
     })
 }
 
@@ -2549,6 +2610,9 @@ fn apply_cli_overrides(runtime: &mut RuntimeConfig, cli: &Cli) {
     }
     if let Some(vitis_cache_key) = &cli.vitis_cache_key {
         runtime.vitis_cache_key = Some(vitis_cache_key.clone());
+    }
+    if let Some(backend) = &cli.backend {
+        runtime.backend = Some(backend.clone());
     }
     if let Some(capability_override) = cli.capability_override {
         runtime.capability_override = Some(capability_override);
@@ -2651,6 +2715,10 @@ fn apply_fragment_with_source(
         runtime.vitis_cache_key = Some(vitis_cache_key.clone());
         sources.vitis_cache_key = source.to_string();
     }
+    if let Some(backend) = &fragment.backend {
+        runtime.backend = Some(backend.clone());
+        sources.backend = source.to_string();
+    }
 }
 
 fn apply_cli_overrides_with_source(
@@ -2749,6 +2817,10 @@ fn apply_cli_overrides_with_source(
     if let Some(vitis_cache_key) = &cli.vitis_cache_key {
         runtime.vitis_cache_key = Some(vitis_cache_key.clone());
         sources.vitis_cache_key = "cli --vitis-cache-key".to_string();
+    }
+    if let Some(backend) = &cli.backend {
+        runtime.backend = Some(backend.clone());
+        sources.backend = "cli --backend".to_string();
     }
     if let Some(capability_override) = cli.capability_override {
         runtime.capability_override = Some(capability_override);
@@ -3733,6 +3805,7 @@ impl RuntimeConfigView {
             vitis_config: runtime.vitis_config.clone(),
             vitis_cache_dir: runtime.vitis_cache_dir.clone(),
             vitis_cache_key: runtime.vitis_cache_key.clone(),
+            backend: runtime.backend.clone(),
         }
     }
 }
@@ -3923,6 +3996,59 @@ fn run_doctor(cli: &Cli) -> DoctorReport {
                             ),
                         );
                     }
+                }
+
+                // Inference backend diagnostics.
+                let registry = ProviderRegistry::discover();
+                for bd in registry.diagnose_all() {
+                    let status = if bd.info.available {
+                        DoctorStatus::Pass
+                    } else {
+                        DoctorStatus::Warn
+                    };
+                    let availability = if bd.info.available {
+                        "available"
+                    } else {
+                        "not available"
+                    };
+                    report.push(
+                        status,
+                        "inference-backend",
+                        format!(
+                            "{} (priority {}) — {}",
+                            bd.info.name, bd.info.priority, availability
+                        ),
+                    );
+                    let mut backend_diags = Vec::new();
+                    for diag in &bd.diagnostics {
+                        let diag_status = match diag.severity {
+                            inference_bridge::backend::DiagnosticSeverity::Pass => {
+                                DoctorStatus::Pass
+                            }
+                            inference_bridge::backend::DiagnosticSeverity::Warn => {
+                                DoctorStatus::Warn
+                            }
+                            inference_bridge::backend::DiagnosticSeverity::Fail => {
+                                DoctorStatus::Fail
+                            }
+                        };
+                        report.push(
+                            diag_status,
+                            "inference-backend",
+                            format!("  {} — {}: {}", bd.info.name, diag.check, diag.message),
+                        );
+                        backend_diags.push(DoctorBackendDiag {
+                            status: diag_status,
+                            check: diag.check.clone(),
+                            detail: diag.message.clone(),
+                        });
+                    }
+                    report.backends.push(DoctorBackendEntry {
+                        name: bd.info.name,
+                        priority: bd.info.priority,
+                        available: bd.info.available,
+                        diagnostics: backend_diags,
+                    });
                 }
 
                 // Plugin tools check.
@@ -4492,6 +4618,7 @@ fn render_doctor_report_json(report: &DoctorReport) -> Result<String> {
             fail: fail_count,
         },
         checks: &report.checks,
+        backends: &report.backends,
     };
     render_json_with_contract(&view)
 }
@@ -5744,9 +5871,14 @@ async fn run_agent_once(runtime: &RuntimeConfig, dry_run: bool) -> Result<RunRep
         validate_live_runtime_preflight(runtime)?;
     }
 
+    // Resolve inference backend.
+    let registry = ProviderRegistry::discover();
+    let resolved_backend_name = resolve_backend(&registry, runtime)?;
+
     let vitis_config = build_vitis_config(runtime);
     let (backend_override, backend_config) = match vitis_config {
         Some(cfg) => (Some("vitis".to_string()), cfg.into_backend_config()),
+        None if runtime.backend.is_some() => (runtime.backend.clone(), Default::default()),
         None => (None, Default::default()),
     };
     let model_config = ModelConfig {
@@ -5758,6 +5890,8 @@ async fn run_agent_once(runtime: &RuntimeConfig, dry_run: bool) -> Result<RunRep
         backend_override,
         backend_config,
     };
+
+    tracing::info!(backend = %resolved_backend_name, "Selected inference backend");
 
     // Determine capability tier: override > probe > default.
     let (tier, capability_report) = if let Some(cap_override) = runtime.capability_override {
@@ -5800,7 +5934,50 @@ async fn run_agent_once(runtime: &RuntimeConfig, dry_run: bool) -> Result<RunRep
         agent = agent.with_coverage_baseline(coverage_baseline);
     }
 
-    agent.run(&runtime.task).await
+    let mut report = agent.run(&runtime.task).await?;
+    report.backend = Some(resolved_backend_name);
+    Ok(report)
+}
+
+/// Resolve which backend to use based on `--backend` flag or auto-select.
+fn resolve_backend(registry: &ProviderRegistry, runtime: &RuntimeConfig) -> Result<String> {
+    if let Some(requested) = &runtime.backend {
+        if requested.eq_ignore_ascii_case("auto") {
+            // Explicit "auto" — fall through to auto-select.
+        } else {
+            // User asked for a specific backend.
+            match registry.get(requested) {
+                Some(backend) => {
+                    if backend.is_available() {
+                        return Ok(backend.name().to_string());
+                    }
+                    bail!(
+                        "{} backend is registered but not available on this system",
+                        backend.name()
+                    );
+                }
+                None => {
+                    let available = registry
+                        .list()
+                        .iter()
+                        .map(|p| p.name.clone())
+                        .collect::<Vec<_>>()
+                        .join(", ");
+                    bail!(
+                        "\"{}\" backend not found; available backends: {}",
+                        requested,
+                        available
+                    );
+                }
+            }
+        }
+    }
+
+    // Auto-select: pick highest-priority available backend.
+    match registry.best_available() {
+        Some(backend) => Ok(backend.name().to_string()),
+        None => bail!("no inference backend available"),
+    }
 }
 
 fn append_live_fallback_finding(report: &mut RunReport, decision: &LiveFallbackDecision) {
@@ -6006,6 +6183,7 @@ mod tests {
             vitis_config: None,
             vitis_cache_dir: None,
             vitis_cache_key: None,
+            backend: None,
             capability_override: None,
             tools_dir: None,
             allowed_plugins: vec![],
@@ -6017,6 +6195,7 @@ mod tests {
             task: "Check suspicious listener ports and summarize risk".to_string(),
             case_id: Some("CASE-2026-0001".to_string()),
             max_severity: Some(FindingSeverity::Medium),
+            backend: None,
             model_capability: None,
             live_fallback_decision: None,
             run_timing: None,
@@ -6673,6 +6852,7 @@ mod tests {
                     ..SettingsFragment::default()
                 },
             )]),
+            ..Default::default()
         };
 
         let env_overrides = SettingsFragment {
@@ -6911,6 +7091,7 @@ mod tests {
                 ("team-default".to_string(), SettingsFragment::default()),
                 ("incident-hotfix".to_string(), SettingsFragment::default()),
             ]),
+            ..Default::default()
         };
 
         let rendered = render_profile_list(
@@ -6930,6 +7111,7 @@ mod tests {
         let file_config = FileConfig {
             defaults: SettingsFragment::default(),
             profiles: HashMap::from([("incident-hotfix".to_string(), SettingsFragment::default())]),
+            ..Default::default()
         };
 
         let rendered = render_profile_list_json(

--- a/core_engine/src/agent.rs
+++ b/core_engine/src/agent.rs
@@ -117,6 +117,7 @@ impl<B: InferenceEngine> Agent<B> {
                 task: task.to_string(),
                 case_id: None,
                 max_severity: Some(FindingSeverity::Info),
+                backend: None,
                 model_capability: self.model_capability_report.clone(),
                 live_fallback_decision: None,
                 run_timing: Some(build_run_timing_metrics(run_started_at, None)),
@@ -212,6 +213,7 @@ impl<B: InferenceEngine> Agent<B> {
             task: task.to_string(),
             case_id: None,
             max_severity: report_max_severity,
+            backend: None,
             model_capability: self.model_capability_report.clone(),
             live_fallback_decision: None,
             run_timing: Some(build_run_timing_metrics(

--- a/core_engine/src/lib.rs
+++ b/core_engine/src/lib.rs
@@ -361,6 +361,8 @@ pub struct RunReport {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub max_severity: Option<FindingSeverity>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub backend: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub model_capability: Option<ModelCapabilityReport>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub live_fallback_decision: Option<LiveFallbackDecision>,

--- a/docs/schemas/doctor-introspection.schema.json
+++ b/docs/schemas/doctor-introspection.schema.json
@@ -54,6 +54,46 @@
         },
         "additionalProperties": false
       }
+    },
+    "backends": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "priority", "available", "diagnostics"],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "priority": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "available": {
+            "type": "boolean"
+          },
+          "diagnostics": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": ["status", "check", "detail"],
+              "properties": {
+                "status": {
+                  "type": "string",
+                  "enum": ["pass", "warn", "fail"]
+                },
+                "check": {
+                  "type": "string"
+                },
+                "detail": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            }
+          }
+        },
+        "additionalProperties": false
+      }
     }
   },
   "additionalProperties": false

--- a/docs/schemas/examples/doctor-introspection.example.json
+++ b/docs/schemas/examples/doctor-introspection.example.json
@@ -1,7 +1,7 @@
 {
   "contract_version": "1.0.0",
   "summary": {
-    "pass": 5,
+    "pass": 7,
     "warn": 1,
     "fail": 0
   },
@@ -37,6 +37,30 @@
       "detail": "Vitis config is set but file was not found: ./models/vitis_ep.json",
       "reason_code": "vitis_config_missing",
       "remediation": "Install the RyzenAI SDK or set ORT_DYLIB_PATH to a Vitis-enabled ONNX Runtime build."
+    },
+    {
+      "status": "pass",
+      "name": "inference-backend",
+      "detail": "CPU (priority 0) — available"
+    },
+    {
+      "status": "pass",
+      "name": "inference-backend",
+      "detail": "  CPU — cpu-backend: CPU execution provider is always available"
+    }
+  ],
+  "backends": [
+    {
+      "name": "CPU",
+      "priority": 0,
+      "available": true,
+      "diagnostics": [
+        {
+          "status": "pass",
+          "check": "cpu-backend",
+          "detail": "CPU execution provider is always available"
+        }
+      ]
     }
   ]
 }

--- a/docs/schemas/examples/run-report.example.json
+++ b/docs/schemas/examples/run-report.example.json
@@ -3,6 +3,7 @@
   "task": "Investigate unauthorized SSH keys",
   "case_id": "CASE-2026-IR-1001",
   "max_severity": "medium",
+  "backend": "CPU",
   "model_capability": {
     "tier": "basic",
     "estimated_params_b": 1.2,

--- a/docs/schemas/run-report.schema.json
+++ b/docs/schemas/run-report.schema.json
@@ -25,6 +25,10 @@
       "type": ["string", "null"],
       "enum": ["info", "low", "medium", "high", "critical", null]
     },
+    "backend": {
+      "type": ["string", "null"],
+      "description": "Name of the inference backend used for this run (e.g. CPU, AMD Vitis NPU)."
+    },
     "model_capability": {
       "type": ["object", "null"],
       "required": ["tier", "estimated_params_b", "execution_provider", "smoke_latency_ms", "vocab_size"],

--- a/inference_bridge/src/backend.rs
+++ b/inference_bridge/src/backend.rs
@@ -81,6 +81,13 @@ pub struct ProviderInfo {
     pub available: bool,
 }
 
+/// Full diagnostic output for a single backend.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BackendDiagnostics {
+    pub info: ProviderInfo,
+    pub diagnostics: Vec<DiagnosticEntry>,
+}
+
 /// Abstraction over a hardware execution provider.
 ///
 /// Backends report their availability at runtime (not just compile time) so
@@ -199,6 +206,28 @@ impl ProviderRegistry {
                 available: b.is_available(),
             })
             .collect()
+    }
+
+    /// Run diagnostics on every registered backend and return results.
+    ///
+    /// Each entry pairs the backend's [`ProviderInfo`] with its diagnostic
+    /// entries, sorted by descending priority so the most-preferred backend
+    /// appears first.
+    pub fn diagnose_all(&self) -> Vec<BackendDiagnostics> {
+        let mut results: Vec<BackendDiagnostics> = self
+            .backends
+            .iter()
+            .map(|b| BackendDiagnostics {
+                info: ProviderInfo {
+                    name: b.name().to_string(),
+                    priority: b.priority(),
+                    available: b.is_available(),
+                },
+                diagnostics: b.diagnose(),
+            })
+            .collect();
+        results.sort_by_key(|b| std::cmp::Reverse(b.info.priority));
+        results
     }
 
     /// Lists the names of all available backends.

--- a/inference_bridge/tests/backend_conformance.rs
+++ b/inference_bridge/tests/backend_conformance.rs
@@ -1,0 +1,195 @@
+//! Multi-backend conformance test harness.
+//!
+//! This module validates that every `ExecutionProviderBackend` implementation
+//! satisfies the trait contract. Adding a new backend requires only one
+//! invocation of the `backend_contract_tests!` macro.
+
+use inference_bridge::backend::{
+    BackendOptions, CpuBackend, DiagnosticSeverity, ExecutionProviderBackend, ProviderRegistry,
+};
+use inference_bridge::ModelConfig;
+use std::path::PathBuf;
+
+fn test_model_config(dry_run: bool) -> ModelConfig {
+    ModelConfig {
+        model_path: PathBuf::from("tests/fixtures/dummy.onnx"),
+        tokenizer_path: None,
+        max_new_tokens: 1,
+        temperature: 0.0,
+        dry_run,
+        backend_override: None,
+        backend_config: Default::default(),
+    }
+}
+
+/// Contract test suite exercised against each compiled backend.
+macro_rules! backend_contract_tests {
+    ($mod_name:ident, $backend_expr:expr) => {
+        mod $mod_name {
+            use super::*;
+
+            fn backend() -> impl ExecutionProviderBackend {
+                $backend_expr
+            }
+
+            #[test]
+            fn name_is_non_empty() {
+                assert!(
+                    !backend().name().is_empty(),
+                    "backend name must not be empty"
+                );
+            }
+
+            #[test]
+            fn name_is_ascii() {
+                assert!(
+                    backend().name().is_ascii(),
+                    "backend name should be ASCII for consistent matching"
+                );
+            }
+
+            #[test]
+            fn priority_is_finite() {
+                // priority is u32 so always finite, but verify it's accessible
+                let _ = backend().priority();
+            }
+
+            #[test]
+            fn is_available_is_deterministic() {
+                let a = backend().is_available();
+                let b = backend().is_available();
+                assert_eq!(a, b, "is_available() should be deterministic across calls");
+            }
+
+            #[test]
+            fn config_keys_are_non_empty_strings() {
+                for key in backend().config_keys() {
+                    assert!(!key.is_empty(), "config key must not be empty");
+                }
+            }
+
+            #[test]
+            fn diagnose_returns_entries() {
+                let entries = backend().diagnose();
+                // Every backend should report at least one diagnostic.
+                assert!(
+                    !entries.is_empty(),
+                    "diagnose() must return at least one entry"
+                );
+            }
+
+            #[test]
+            fn diagnose_entries_are_well_formed() {
+                for entry in backend().diagnose() {
+                    assert!(
+                        !entry.check.is_empty(),
+                        "diagnostic check name must not be empty"
+                    );
+                    assert!(
+                        !entry.message.is_empty(),
+                        "diagnostic message must not be empty"
+                    );
+                    // Severity must be one of the defined variants.
+                    match entry.severity {
+                        DiagnosticSeverity::Pass
+                        | DiagnosticSeverity::Warn
+                        | DiagnosticSeverity::Fail => {}
+                    }
+                }
+            }
+
+            #[test]
+            fn dry_run_session_succeeds() {
+                let config = test_model_config(true);
+                let session = backend().build_session(&config, &BackendOptions::new());
+                assert!(
+                    session.is_ok(),
+                    "build_session with dry_run=true should always succeed: {:?}",
+                    session.err()
+                );
+            }
+
+            #[test]
+            fn dry_run_session_generates() {
+                let config = test_model_config(true);
+                let session = backend()
+                    .build_session(&config, &BackendOptions::new())
+                    .expect("dry-run session build");
+                let result = session.generate("test prompt", 10);
+                assert!(result.is_ok(), "dry-run generate should succeed");
+                assert!(
+                    !result.unwrap().is_empty(),
+                    "dry-run generate should return non-empty text"
+                );
+            }
+        }
+    };
+}
+
+// -----------------------------------------------------------------------
+// Invoke the conformance suite for each compiled backend.
+// -----------------------------------------------------------------------
+
+backend_contract_tests!(cpu_conformance, CpuBackend);
+
+#[cfg(feature = "vitis")]
+backend_contract_tests!(vitis_conformance, inference_bridge::backend::VitisBackend);
+
+// -----------------------------------------------------------------------
+// Registry-level tests
+// -----------------------------------------------------------------------
+
+#[test]
+fn registry_discover_is_non_empty() {
+    let registry = ProviderRegistry::discover();
+    assert!(!registry.list().is_empty());
+}
+
+#[test]
+fn registry_diagnose_all_covers_all_backends() {
+    let registry = ProviderRegistry::discover();
+    let list = registry.list();
+    let diags = registry.diagnose_all();
+    assert_eq!(
+        list.len(),
+        diags.len(),
+        "diagnose_all should return one entry per registered backend"
+    );
+}
+
+#[test]
+fn registry_diagnose_all_sorted_by_priority_desc() {
+    let registry = ProviderRegistry::discover();
+    let diags = registry.diagnose_all();
+    for window in diags.windows(2) {
+        assert!(
+            window[0].info.priority >= window[1].info.priority,
+            "diagnose_all results should be sorted by descending priority"
+        );
+    }
+}
+
+#[test]
+fn registry_best_available_matches_highest_priority() {
+    let registry = ProviderRegistry::discover();
+    let best = registry.best_available().expect("at least one backend");
+    let all_available: Vec<_> = registry
+        .list()
+        .into_iter()
+        .filter(|p| p.available)
+        .collect();
+    let max_priority = all_available.iter().map(|p| p.priority).max().unwrap();
+    assert_eq!(best.priority(), max_priority);
+}
+
+#[test]
+fn registry_build_session_with_fallback_dry_run() {
+    let registry = ProviderRegistry::discover();
+    let config = test_model_config(true);
+    let result = registry.build_session_with_fallback(&config, &BackendOptions::new(), None);
+    assert!(result.is_ok());
+    let (name, session) = result.unwrap();
+    assert!(!name.is_empty());
+    let output = session.generate("hello", 1).unwrap();
+    assert!(!output.is_empty());
+}

--- a/wraithrun.example.toml
+++ b/wraithrun.example.toml
@@ -24,6 +24,12 @@ log = "normal"
 # evidence_bundle_archive = "./evidence/CASE-2026-0001.tar"
 # baseline_bundle = "./evidence/CASE-2026-0001"
 
+# Inference backend selection.
+# "auto" (default) picks the highest-priority available backend.
+# Explicit values: "cpu", "vitis", etc.
+[inference]
+backend = "auto"
+
 [profiles.local-lab]
 max_steps = 6
 max_new_tokens = 192


### PR DESCRIPTION
## Summary

Implements the final three issues for the v1.3.0 Multi-Backend Inference Abstraction milestone.

### #52 Provider-aware doctor diagnostics
- **`ProviderRegistry::diagnose_all()`** iterates every registered backend and returns `BackendDiagnostics` (info + diagnostic entries), sorted by priority descending
- **`wraithrun doctor`** now enumerates all compiled backends with availability status and per-backend diagnostic checks
- **Doctor JSON** output includes a `backends` array conforming to the updated `doctor-introspection.schema.json`
- Schema and example updated in `docs/schemas/`

### #53 CLI `--backend` flag and auto-select strategy
- **`--backend <NAME>`** flag added to override automatic backend selection (accepts `ExecutionProviderBackend::name()` values)
- **`[inference]` TOML section** supported with `backend = auto` (default) or explicit backend name
- **`WRAITHRUN_BACKEND`** environment variable support
- **Auto-select** picks highest-priority available backend when no override given
- **Helpful error** when the requested backend is unavailable or unknown (lists available backends)
- **Run report JSON** includes `backend` field with the selected backend name
- Run-report schema and example updated

### #54 Integration test harness for multi-backend conformance
- **`backend_contract_tests!`** macro generates 9 contract tests per backend (name, priority, availability, determinism, config_keys, diagnostics, sessions)
- **5 registry-level tests** (discover, diagnose_all ordering, best_available consistency, fallback build)
- CPU conformance suite runs on every CI leg; Vitis suite runs when compiled with `vitis` feature
- Adding a new backend requires only one line: `backend_contract_tests!(name, BackendType)`

### Test results
- 259 tests passing (14 new conformance tests)
- Clippy clean (`-D warnings`)
- `cargo fmt --all -- --check` clean

Closes #52, closes #53, closes #54