### PR TITLE
docs: add CHANGELOG and upgrades entries for v1.7.0 and v1.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,38 @@ The format is inspired by Keep a Changelog and this project follows Semantic Ver
 
 - (none yet)
 
+## 1.7.1 - 2026-04-05
+
+### Changed
+
+- Bumped `toml` from 0.8 to 1.1.
+- Bumped `thiserror` from 1.0 to 2.0.
+- Bumped `sha2` from 0.10 to 0.11 and updated digest hex formatting to use the new API.
+- Bumped CI actions: `actions/checkout` v6, `actions/upload-artifact` v7, `actions/download-artifact` v8, `actions/setup-python` v6, `release-drafter/release-drafter` v7.
+
+## 1.7.0 - 2026-04-05
+
+### Added
+
+- Per-tool `elapsed_ms` timing in investigation output (#129).
+- LLM chain-of-thought reasoning captured in `llm_reasoning` field for Moderate/Strong tiers (#119).
+- Small model warning when the loaded model has fewer than 100M parameters (#120).
+- Evidence-derived confidence scoring with corroboration bonus across tools (#121).
+- Task-specific `basic_tier_summary_for_task()` synthesis for Basic tier investigations (#122).
+- Placeholder checksum detection: model packs with all-zero or repeated-byte SHA-256 hashes are rejected (#123).
+- Model preset auto-discovery: searches `models/` subdirectories for matching ONNX files when the default path is not found (#124).
+- Expanded privilege-escalation checks: AlwaysInstallElevated, unquoted service paths, and 9 additional markers (#125).
+- Expanded persistence detection: RunOnce, Winlogon, IFEO, AppInit_DLLs, user systemd services, and crontab entries (#126).
+- Tokenizer grandparent directory search for `tokenizer.json` alongside model files (#128).
+
+### Fixed
+
+- KV-cache off-by-one error that could skip the first generated token (#114).
+- Model parameter estimation now uses tensor shape products instead of raw dimension sums (#115).
+- CLI feature forwarding passes `--temperature`, `--backend`, and `--model-download` through to the engine (#116).
+- Dry-run template matching works correctly for all registered tool names (#117).
+- Dry-run multi-tool iteration no longer stops after the first tool (#118).
+
 ## 1.6.0 - 2026-04-05
 
 ### Added

--- a/docs/upgrades.md
+++ b/docs/upgrades.md
@@ -1,5 +1,25 @@
 # Upgrade Notes
 
+## v1.7.1
+
+- Dependency-only release. No breaking API changes.
+- `sha2` 0.11 changes the `Display`/`LowerHex` impl on digest types. If you format hashes via `format!("{:x}", digest)`, switch to iterating over `digest.as_slice()` with per-byte hex formatting.
+- CI action versions bumped (checkout v6, upload-artifact v7, download-artifact v8, setup-python v6, release-drafter v7). No user-facing impact unless you pin these in your own workflows.
+
+## v1.7.0
+
+### Breaking/visible changes
+
+- **`RunReport` gains new fields**: `elapsed_ms` per tool entry, `llm_reasoning` on Moderate/Strong tier results, and `confidence` score with corroboration metadata. Consumers parsing JSON reports should handle these new optional fields.
+- **Basic tier now emits a summary**: `basic_tier_summary_for_task()` produces a short task-context summary even without LLM synthesis. Previously Basic tier returned raw tool output only.
+- **Small model warning**: models with fewer than 100M estimated parameters emit a warning at load time. This is informational and does not block execution.
+
+### Migration
+
+- No TOML config changes required.
+- If you parse `RunReport` JSON, add handling for the new optional `elapsed_ms`, `llm_reasoning`, and `confidence` fields.
+- Model packs with placeholder (all-zero) SHA-256 checksums will now be rejected. Re-download any affected packs.
+
 ## v1.6.0
 
 ### Breaking/visible changes


### PR DESCRIPTION
The v1.7.0 and v1.7.1 release workflows failed because CHANGELOG.md and docs/upgrades.md were missing the required version sections. This adds the entries so the release preflight checks pass.