### PR TITLE
fix: resolve 8 live-evaluation issues (#136-#142)

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -3560,7 +3560,11 @@ fn sha256_file(path: &Path) -> Result<String> {
     let data = fs::read(path).with_context(|| format!("failed to read '{}'", path.display()))?;
     let mut hasher = Sha256::new();
     hasher.update(&data);
-    Ok(hasher.finalize().iter().map(|b| format!("{b:02x}")).collect())
+    Ok(hasher
+        .finalize()
+        .iter()
+        .map(|b| format!("{b:02x}"))
+        .collect())
 }
 
 /// Returns true when the checksum is a placeholder string that cannot be
@@ -5561,7 +5565,11 @@ fn extract_string_array(value: Option<&Value>, max_items: usize, max_chars: usiz
 fn sha256_hex(bytes: &[u8]) -> String {
     let mut hasher = Sha256::new();
     hasher.update(bytes);
-    hasher.finalize().iter().map(|b| format!("{b:02x}")).collect()
+    hasher
+        .finalize()
+        .iter()
+        .map(|b| format!("{b:02x}"))
+        .collect()
 }
 
 fn render_summary(report: &RunReport) -> String {

--- a/core_engine/src/agent.rs
+++ b/core_engine/src/agent.rs
@@ -8,9 +8,8 @@ use inference_bridge::InferenceEngine;
 
 use crate::{
     basic_tier_summary_for_task, builtin_investigation_templates, deduplicate_findings,
-    derive_findings,
-    extract_tag, max_severity, quality_checked_final_answer, sort_findings, AgentTurn,
-    CoverageBaseline, EvidencePointer, Finding, FindingSeverity, InvestigationTemplate,
+    derive_findings, extract_tag, max_severity, quality_checked_final_answer, sort_findings,
+    AgentTurn, CoverageBaseline, EvidencePointer, Finding, FindingSeverity, InvestigationTemplate,
     ModelCapabilityReport, ModelCapabilityTier, RunReport, RunTimingMetrics, ToolCall,
 };
 
@@ -299,8 +298,8 @@ impl<B: InferenceEngine> Agent<B> {
                         transcript.push_str(&format!("\n{output}\nObservation: {obs_truncated}\n"));
 
                         // Extract LLM chain-of-thought: text before <call> tag (#119).
-                        let thought = extract_pre_tag_thought(&output, "call")
-                            .unwrap_or_else(|| {
+                        let thought =
+                            extract_pre_tag_thought(&output, "call").unwrap_or_else(|| {
                                 format!("ReAct step {}: invoking {}", step + 1, call.tool)
                             });
 

--- a/core_engine/src/lib.rs
+++ b/core_engine/src/lib.rs
@@ -621,7 +621,8 @@ pub fn derive_findings(turns: &[AgentTurn], final_answer: &str) -> Vec<Finding> 
                     FindingSeverity::Low
                 };
                 // Extract account names for detail.
-                let detail = extract_string_list_summary(observation, "non_default_privileged_accounts", 3);
+                let detail =
+                    extract_string_list_summary(observation, "non_default_privileged_accounts", 3);
                 let title = if detail.is_empty() {
                     format!("Non-default privileged accounts observed ({non_default_privileged_account_count})")
                 } else {
@@ -848,20 +849,28 @@ pub fn derive_findings(turns: &[AgentTurn], final_answer: &str) -> Vec<Finding> 
                 };
 
                 // Build detail string from directories.
-                let detail = if let Some(dirs) = observation.get("directories").and_then(Value::as_array) {
-                    let summaries: Vec<String> = dirs.iter().take(3).map(|d| {
-                        let dir = d.get("ssh_dir").and_then(Value::as_str).unwrap_or("?");
-                        let has_ak = d.get("has_authorized_keys").and_then(Value::as_bool).unwrap_or(false);
-                        format!("{dir} (authorized_keys: {has_ak})")
-                    }).collect();
-                    if dirs.len() > 3 {
-                        format!("{} and {} more", summaries.join(", "), dirs.len() - 3)
+                let detail =
+                    if let Some(dirs) = observation.get("directories").and_then(Value::as_array) {
+                        let summaries: Vec<String> = dirs
+                            .iter()
+                            .take(3)
+                            .map(|d| {
+                                let dir = d.get("ssh_dir").and_then(Value::as_str).unwrap_or("?");
+                                let has_ak = d
+                                    .get("has_authorized_keys")
+                                    .and_then(Value::as_bool)
+                                    .unwrap_or(false);
+                                format!("{dir} (authorized_keys: {has_ak})")
+                            })
+                            .collect();
+                        if dirs.len() > 3 {
+                            format!("{} and {} more", summaries.join(", "), dirs.len() - 3)
+                        } else {
+                            summaries.join(", ")
+                        }
                     } else {
-                        summaries.join(", ")
-                    }
-                } else {
-                    String::new()
-                };
+                        String::new()
+                    };
 
                 findings.push(Finding::new(
                     format!(
@@ -1097,8 +1106,11 @@ fn is_low_quality(text: &str) -> bool {
         .lines()
         .filter(|line| {
             let l = line.trim();
-            l.starts_with("1)") || l.starts_with("2)") || l.starts_with("3)")
-                || l.starts_with("4)") || l.starts_with("5)")
+            l.starts_with("1)")
+                || l.starts_with("2)")
+                || l.starts_with("3)")
+                || l.starts_with("4)")
+                || l.starts_with("5)")
         })
         .count();
     if numbered_lines >= 3 && menu_hits >= 1 {
@@ -1159,7 +1171,9 @@ pub fn basic_tier_summary(findings: &[Finding]) -> String {
 pub fn basic_tier_summary_for_task(findings: &[Finding], task: Option<&str>) -> String {
     if findings.is_empty() {
         let prefix = match task {
-            Some(t) => format!("SUMMARY: Task \"{t}\" completed with 0 findings. Maximum severity: info."),
+            Some(t) => {
+                format!("SUMMARY: Task \"{t}\" completed with 0 findings. Maximum severity: info.")
+            }
             None => "SUMMARY: 0 findings detected. Maximum severity: info.".to_string(),
         };
         return format!("{prefix}\nFINDINGS:\n(none)\nRISK: info\nACTIONS:\n(none)");
@@ -1266,12 +1280,7 @@ fn extract_string_list_summary(observation: &Value, field: &str, max: usize) -> 
     let items: Vec<&str> = observation
         .get(field)
         .and_then(Value::as_array)
-        .map(|arr| {
-            arr.iter()
-                .filter_map(Value::as_str)
-                .take(max + 1)
-                .collect()
-        })
+        .map(|arr| arr.iter().filter_map(Value::as_str).take(max + 1).collect())
         .unwrap_or_default();
 
     if items.is_empty() {

--- a/cyber_tools/src/lib.rs
+++ b/cyber_tools/src/lib.rs
@@ -709,11 +709,7 @@ impl Tool for CheckPrivilegeEscalationVectorsTool {
                     .collect();
 
                 for svc in service_names {
-                    if let Ok(qc_out) = Command::new("sc")
-                        .args(["qc", svc])
-                        .output()
-                        .await
-                    {
+                    if let Ok(qc_out) = Command::new("sc").args(["qc", svc]).output().await {
                         let qc_stdout = String::from_utf8_lossy(&qc_out.stdout);
                         for line in qc_stdout.lines() {
                             let trimmed = line.trim();
@@ -1206,7 +1202,9 @@ impl Tool for EnumerateSshKeysTool {
     fn spec(&self) -> ToolSpec {
         ToolSpec {
             name: "enumerate_ssh_keys".to_string(),
-            description: "Enumerates SSH keys and authorized_keys files for all user accounts on the host.".to_string(),
+            description:
+                "Enumerates SSH keys and authorized_keys files for all user accounts on the host."
+                    .to_string(),
             args_schema: json!({
                 "type": "object",
                 "properties": {
@@ -1260,7 +1258,11 @@ impl Tool for EnumerateSshKeysTool {
                 if let Ok(entries) = std::fs::read_dir(ssh_dir) {
                     for entry in entries.flatten() {
                         let path = entry.path();
-                        let fname = path.file_name().unwrap_or_default().to_string_lossy().to_string();
+                        let fname = path
+                            .file_name()
+                            .unwrap_or_default()
+                            .to_string_lossy()
+                            .to_string();
 
                         if fname == "authorized_keys" || fname == "authorized_keys2" {
                             has_authorized_keys = true;
@@ -1327,7 +1329,11 @@ impl Tool for EnumerateSshKeysTool {
                 if let Ok(entries) = std::fs::read_dir(ssh_dir) {
                     for entry in entries.flatten() {
                         let path = entry.path();
-                        let fname = path.file_name().unwrap_or_default().to_string_lossy().to_string();
+                        let fname = path
+                            .file_name()
+                            .unwrap_or_default()
+                            .to_string_lossy()
+                            .to_string();
 
                         if fname == "authorized_keys" || fname == "authorized_keys2" {
                             has_authorized_keys = true;

--- a/inference_bridge/src/lib.rs
+++ b/inference_bridge/src/lib.rs
@@ -99,14 +99,15 @@ fn estimate_params_from_file_size(model_path: &PathBuf) -> f32 {
 /// Infer bytes-per-parameter from filename conventions.
 /// Falls back to 2.2 (FP16) if no quantization hint is found.
 fn detect_quant_bytes_per_param(model_path: &Path) -> f64 {
-    let path_lower = model_path
-        .to_string_lossy()
-        .to_lowercase();
+    let path_lower = model_path.to_string_lossy().to_lowercase();
 
     // Check filename and parent directory for quantization hints.
     if path_lower.contains("q4") || path_lower.contains("int4") || path_lower.contains("4bit") {
         0.55
-    } else if path_lower.contains("q8") || path_lower.contains("int8") || path_lower.contains("8bit") {
+    } else if path_lower.contains("q8")
+        || path_lower.contains("int8")
+        || path_lower.contains("8bit")
+    {
         1.1
     } else if path_lower.contains("fp32") || path_lower.contains("float32") {
         4.4
@@ -130,7 +131,9 @@ struct DryRunTemplate {
 static DRY_RUN_TEMPLATES: &[DryRunTemplate] = &[
     // baseline-capture — must outrank baseline-drift when "capture"/"coverage" present.
     DryRunTemplate {
-        keywords: &["capture", "snapshot", "collect", "coverage", "baseline", "golden"],
+        keywords: &[
+            "capture", "snapshot", "collect", "coverage", "baseline", "golden",
+        ],
         tools: &["capture_coverage_baseline"],
     },
     // file-integrity
@@ -192,8 +195,14 @@ static DRY_RUN_TEMPLATES: &[DryRunTemplate] = &[
     // network-exposure-audit
     DryRunTemplate {
         keywords: &[
-            "network", "connection", "port", "listen", "listener", "lateral",
-            "beacon", "socket",
+            "network",
+            "connection",
+            "port",
+            "listen",
+            "listener",
+            "lateral",
+            "beacon",
+            "socket",
         ],
         tools: &[
             "scan_network",
@@ -203,7 +212,15 @@ static DRY_RUN_TEMPLATES: &[DryRunTemplate] = &[
     },
     // privilege-escalation
     DryRunTemplate {
-        keywords: &["privilege", "escalat", "admin", "root", "sudo", "whoami", "unauthori"],
+        keywords: &[
+            "privilege",
+            "escalat",
+            "admin",
+            "root",
+            "sudo",
+            "whoami",
+            "unauthori",
+        ],
         tools: &[
             "check_privilege_escalation_vectors",
             "audit_account_changes",
@@ -644,7 +661,8 @@ mod tests {
         let out2 = engine.dry_run_response(&format!("{task}\nObservation: {{}}"));
         assert!(out2.contains("\"tool\":\"audit_account_changes\""));
 
-        let out3 = engine.dry_run_response(&format!("{task}\nObservation: {{}}\nObservation: {{}}"));
+        let out3 =
+            engine.dry_run_response(&format!("{task}\nObservation: {{}}\nObservation: {{}}"));
         assert!(out3.contains("\"tool\":\"inspect_persistence_locations\""));
 
         let out4 = engine.dry_run_response(&format!("{task}\n...Observation x3..."));

--- a/inference_bridge/src/onnx_vitis.rs
+++ b/inference_bridge/src/onnx_vitis.rs
@@ -2799,8 +2799,7 @@ fn run_prompt_on_session(
 
             debug!(
                 prompt_tokens = context_ids.len(),
-                initial_cache_len,
-                attention_len, "running batch prefill forward pass (cached)"
+                initial_cache_len, attention_len, "running batch prefill forward pass (cached)"
             );
 
             let model_inputs = build_model_inputs(
@@ -3076,8 +3075,7 @@ pub fn run_prompt(config: &ModelConfig, prompt: &str) -> Result<String> {
 
         debug!(
             prompt_tokens = context_ids.len(),
-            initial_cache_len,
-            attention_len, "running batch prefill forward pass"
+            initial_cache_len, attention_len, "running batch prefill forward pass"
         );
 
         let model_inputs =


### PR DESCRIPTION
## Summary
Resolves all 8 issues identified in live evaluation testing across milestones v1.8.0, v1.9.0, and v1.10.0.

## Changes

| Issue | Fix |
|---|---|
| #136 KV-cache attention mask | Account for forced cache padding in prefill attention length (onnx_vitis.rs) |
| #137 ReAct garbage output | Fallback to template execution when <final> produced with no tool calls; detect hallucinated <call> tags in quality guard |
| #138 Parameter estimation | Quantization-aware divisor: Q4=0.55, Q8=1.1, FP16=2.2, FP32=4.4 |
| #139 Severity calibration | Raised listener/persistence thresholds, lowered account severity for normal desktops |
| #140 Findings detail | Extract account names, persistence entries, SSH directory info into finding titles |
| #141 Template-tool mismatches | Fixed file-integrity/ssh-key tool ordering, added syslog-analysis template, added EnumerateSshKeysTool |
| #142 EP reporting | Detect directml/cuda backend overrides |
| #143 API version | Already correct (env!(CARGO_PKG_VERSION)), no code change needed |

## Testing
- 282 unit tests pass, 0 failures
- Clippy clean (--all-targets -D warnings)
- Release build with and without ONNX feature succeeds
- Live tested: Qwen2.5-0.5B (basic tier), Llama-3.2-1B (moderate tier)
- Dry-run tested: all 5 templates (ssh-keys, listener-risk, hash-integrity, priv-esc-review, syslog-summary)

## Files changed
- inference_bridge/src/onnx_vitis.rs - KV-cache attention mask fix
- inference_bridge/src/lib.rs - param estimation, EP detection, template SSH fix
- core_engine/src/lib.rs - severity calibration, findings detail, quality guard, templates
- core_engine/src/agent.rs - ReAct fallback, prompt engineering
- cyber_tools/src/lib.rs - EnumerateSshKeysTool

Closes #136, closes #137, closes #138, closes #139, closes #140, closes #141, closes #142, closes #143